### PR TITLE
Apply uniform bucket-level access on GCS bucket

### DIFF
--- a/terraform/security/logging.tf
+++ b/terraform/security/logging.tf
@@ -20,6 +20,7 @@ resource "google_storage_bucket" "log-bucket" {
   storage_class = "NEARLINE"
   force_destroy = true
   project       = var.governance_project_id
+  uniform_bucket_level_access = true
 }
 
 //Create BQ Data Set in Governance Project


### PR DESCRIPTION
In order to execute in a google.com project (anthos-experimental folder), it's necessary to enable uniform bucket-level access on the GCS storage bucket.