### PR TITLE
Update release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,12 +17,11 @@ jobs:
           go-version: '^1.16.0'
       - name: Make all
         run: cd cli && make all
-      - name: Create Release
-        id: create_release
-        uses: shogo82148/actions-create-release@v1
-
-      - uses: shogo82148/actions-upload-release-asset@v1
+      - name: Release Darwin
+        uses: softprops/action-gh-release@v1
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: '["./bin/gkekitctl-*"]'
-#          asset_paths: '["./bin/gkekitctl-darwin", "./bin/gkekitctl-amd64", "./bin/gkekitctl-arm", "./bin/gkekitctl-arm64", "./bin/gkekitctl.exe"]'
+          files: ./cli/bin/gkekitctl-darwin
+      - name: Release Linux
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./cli/bin/gkekitctl-amd64


### PR DESCRIPTION
changed to a newer action plugin that as original is no longer being maintained. Prior release upload plugin did not allow for full glob paths. Closing #79