### PR TITLE
added version flag info and dynamic build ldflags

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,7 +1,7 @@
 Version := $(shell git describe --tags --dirty)
 # Version := "dev"
 GitCommit := $(shell git rev-parse HEAD)
-LDFLAGS := "-s -w -X main.Version=$(Version) -X main.GitCommit=$(GitCommit)"
+LDFLAGS := "-s -w -X gkekitctl/cmd.Version=$(Version) -X gkekitctl/cmd.GitCommit=$(GitCommit)"
 
 .PHONY: all
 all: gofmt dist

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -24,10 +24,16 @@ import (
 
 var cfgFile string
 
+var (
+	Version   string
+	GitCommit string
+)
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "gkekitctl",
-	Short: "Tool to quickly deploy some pretty dope GKE demos",
+	Use:     "gkekitctl",
+	Version: Version + " : Git Commit : " + GitCommit,
+	Short:   "Tool to quickly deploy some pretty dope GKE demos",
 	Example: `        gkekitctl create 
 	gkectl create --config <file.yaml>
 	gkekitctl delete`,

--- a/cli/main.go
+++ b/cli/main.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package main
 
-import "gkekitctl/cmd"
+import (
+	"gkekitctl/cmd"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
CLI version and gitcommit info will be added at build time if makefile is used to build CLI. The make file was updated to inject the the info into the variables at build time.

Version = Git Release Tag
GitCommit = git Commit SHA of HEAD at build time.

Closes #124 