### PR TITLE
Fix main CI trigger

### DIFF
--- a/test/e2e/cloudbuild-default-config.yaml
+++ b/test/e2e/cloudbuild-default-config.yaml
@@ -124,3 +124,5 @@ availableSecrets:
     env: 'FOLDER_ID'
   - versionName: projects/${PROJECT_ID}/secrets/billing-id/versions/latest
     env: 'BILLING_ID'
+options:
+    substitution_option: 'ALLOW_LOOSE'

--- a/test/e2e/cloudbuild-default-config.yaml
+++ b/test/e2e/cloudbuild-default-config.yaml
@@ -15,9 +15,10 @@ steps:
       export CLEAN_BRANCH_NAME=$_HEAD_BRANCH
     else 
       echo "😺 THIS IS A DIRECT BRANCH COMMIT, NOT A PR, _HEAD_REPO_URL is unset"
-      printev 
+      printenv 
       echo $REPO_NAME
       echo $BRANCH_NAME
+      echo $BUILD_ID
       export CLEAN_REPO_NAME=${REPO_NAME#*//}
       export CLEAN_BRANCH_NAME=$BRANCH_NAME
     fi

--- a/test/e2e/cloudbuild-default-config.yaml
+++ b/test/e2e/cloudbuild-default-config.yaml
@@ -14,13 +14,9 @@ steps:
       export CLEAN_REPO_NAME=${RAW_REPO_NAME#*//}
       export CLEAN_BRANCH_NAME=$_HEAD_BRANCH
     else 
-      echo "😺 THIS IS A DIRECT BRANCH COMMIT, NOT A PR, _HEAD_REPO_URL is unset"
-      printenv 
-      echo $REPO_NAME
-      echo $BRANCH_NAME
-      echo $BUILD_ID
-      export CLEAN_REPO_NAME=${REPO_NAME#*//}
-      export CLEAN_BRANCH_NAME=$BRANCH_NAME
+      echo "😺 THIS IS A DIRECT MAIN BRANCH COMMIT, NOT A PR, _HEAD_REPO_URL is unset"
+      export CLEAN_REPO_NAME="github.com/GoogleCloudPlatform/gke-poc-toolkit"
+      export CLEAN_BRANCH_NAME="main"
     fi
     echo "🌟 REPO INFO: NAME: $$CLEAN_REPO_NAME, BRANCH: $$CLEAN_BRANCH_NAME"
     TIMESTAMP=`date "+%m%d%y-%H%M%S"`

--- a/test/e2e/cloudbuild-default-config.yaml
+++ b/test/e2e/cloudbuild-default-config.yaml
@@ -77,6 +77,7 @@ steps:
   - 'pipefail'
   - '-c'
   - |-
+    env
     cd /workspace/test
     ./gkekitctl init
     if [ -n "$_HEAD_REPO_URL" ]

--- a/test/e2e/cloudbuild-default-config.yaml
+++ b/test/e2e/cloudbuild-default-config.yaml
@@ -7,7 +7,6 @@ steps:
   - 'pipefail'
   - '-c'
   - |-
-    printenv
     if [ -n "$_HEAD_REPO_URL" ]
     then 
       echo "⬆️ THIS IS A PR- _HEAD_REPO_URL is set ($_HEAD_REPO_URL)" 
@@ -16,6 +15,9 @@ steps:
       export CLEAN_BRANCH_NAME=$_HEAD_BRANCH
     else 
       echo "😺 THIS IS A DIRECT BRANCH COMMIT, NOT A PR, _HEAD_REPO_URL is unset"
+      printev 
+      echo $REPO_NAME
+      echo $BRANCH_NAME
       export CLEAN_REPO_NAME=${REPO_NAME#*//}
       export CLEAN_BRANCH_NAME=$BRANCH_NAME
     fi
@@ -126,5 +128,3 @@ availableSecrets:
     env: 'FOLDER_ID'
   - versionName: projects/${PROJECT_ID}/secrets/billing-id/versions/latest
     env: 'BILLING_ID'
-options:
-    substitution_option: 'ALLOW_LOOSE'

--- a/test/e2e/cloudbuild-default-config.yaml
+++ b/test/e2e/cloudbuild-default-config.yaml
@@ -77,7 +77,7 @@ steps:
   - 'pipefail'
   - '-c'
   - |-
-    env
+    printenv
     cd /workspace/test
     ./gkekitctl init
     if [ -n "$_HEAD_REPO_URL" ]

--- a/test/e2e/cloudbuild-default-config.yaml
+++ b/test/e2e/cloudbuild-default-config.yaml
@@ -7,6 +7,7 @@ steps:
   - 'pipefail'
   - '-c'
   - |-
+    printenv
     if [ -n "$_HEAD_REPO_URL" ]
     then 
       echo "⬆️ THIS IS A PR- _HEAD_REPO_URL is set ($_HEAD_REPO_URL)" 

--- a/test/e2e/cloudbuild-default-config.yaml
+++ b/test/e2e/cloudbuild-default-config.yaml
@@ -15,12 +15,12 @@ steps:
       export CLEAN_BRANCH_NAME=$_HEAD_BRANCH
     else 
       echo "😺 THIS IS A DIRECT MAIN BRANCH COMMIT, NOT A PR, _HEAD_REPO_URL is unset"
-      export CLEAN_REPO_NAME="github.com/GoogleCloudPlatform/gke-poc-toolkit"
+      export CLEAN_REPO_NAME="github.com/GoogleCloudPlatform/gke-poc-toolkit//terraform/modules/"
       export CLEAN_BRANCH_NAME="main"
     fi
     echo "🌟 REPO INFO: NAME: $$CLEAN_REPO_NAME, BRANCH: $$CLEAN_BRANCH_NAME"
     TIMESTAMP=`date "+%m%d%y-%H%M%S"`
-    TEST_PROJECT_ID="gpt-$BRANCH_NAME-$$TIMESTAMP"
+    TEST_PROJECT_ID="gpt-$$CLEAN_BRANCH_NAME-$$TIMESTAMP"
     echo $$TEST_PROJECT_ID > /workspace/test-project-id.txt
     gcloud projects create $$TEST_PROJECT_ID --folder="$$FOLDER_ID" 
     gcloud projects add-iam-policy-binding $$TEST_PROJECT_ID --member=serviceAccount:152393131587@cloudbuild.gserviceaccount.com --role=roles/owner
@@ -87,9 +87,9 @@ steps:
       export CLEAN_REPO_NAME=${RAW_REPO_NAME#*//}
       export CLEAN_BRANCH_NAME=$_HEAD_BRANCH
     else 
-      echo "😺 THIS IS A DIRECT BRANCH COMMIT, NOT A PR, _HEAD_REPO_URL is unset"
-      export CLEAN_REPO_NAME=${REPO_NAME#*//}
-      export CLEAN_BRANCH_NAME=$BRANCH_NAME
+      echo "😺 THIS IS A DIRECT MAIN BRANCH COMMIT, NOT A PR, _HEAD_REPO_URL is unset"
+      export CLEAN_REPO_NAME="github.com/GoogleCloudPlatform/gke-poc-toolkit//terraform/modules/"
+      export CLEAN_BRANCH_NAME="main"
     fi
     echo "🌟 REPO INFO: NAME: $$CLEAN_REPO_NAME, BRANCH: $$CLEAN_BRANCH_NAME"
     TEST_PROJECT_ID=$(cat "/workspace/test-project-id.txt")


### PR DESCRIPTION
Cloud Build branch triggers do not seem to have a repo URL variable, just repo name (`gke-poc-toolkit`). For this reason, we need to hardcode the main terraform URL to be able to get the full github URL (`github.com/GoogleCloudPlatform/gke-poc-toolkit`). 

https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values